### PR TITLE
タイトルの状態を管理する

### DIFF
--- a/src/containers/Header/Header.js
+++ b/src/containers/Header/Header.js
@@ -32,7 +32,7 @@ export class Header extends Component {
                 flex: 1
               }}
             >
-              CCPV
+              {this.props.state.title}
             </Typography>
           </Toolbar>
         </AppBar>

--- a/src/containers/ToDo/ToDo.js
+++ b/src/containers/ToDo/ToDo.js
@@ -2,7 +2,13 @@ import React, { Component } from 'react'
 import { addText, clearText } from 'modules/ToDo/actions'
 import { Link } from 'react-router-dom'
 
+import { setTitle } from 'modules/Title/actions'
+
 export class ToDo extends Component {
+  componentDidMount() {
+    this.props.dispatch(setTitle('ToDo'))
+  }
+
   render() {
     return (
       <div>

--- a/src/containers/Top/Top.js
+++ b/src/containers/Top/Top.js
@@ -5,7 +5,13 @@ import { Link } from 'react-router-dom'
 import { Logo } from 'components'
 import './Top.css'
 
+import { setTitle } from 'modules/Title/actions'
+
 export class Top extends Component {
+  componentDidMount() {
+    this.props.dispatch(setTitle('Top'))
+  }
+
   render() {
     return (
       <div className="Top">

--- a/src/modules/Title/actions.js
+++ b/src/modules/Title/actions.js
@@ -1,0 +1,8 @@
+import { SET_TITLE } from './constants'
+
+export const setTitle = title => {
+  return {
+    type: SET_TITLE,
+    title
+  }
+}

--- a/src/modules/Title/constants.js
+++ b/src/modules/Title/constants.js
@@ -1,0 +1,1 @@
+export const SET_TITLE = 'SET_TITLE'

--- a/src/modules/Title/reducers.js
+++ b/src/modules/Title/reducers.js
@@ -1,0 +1,20 @@
+import { SET_TITLE } from './constants'
+
+const title = (state = document.title, action) => {
+  let title
+
+  switch (action.type) {
+    case SET_TITLE:
+      title = action.title
+      break
+    default:
+      title = state
+  }
+
+  // Update document.title
+  document.title = title
+
+  return title
+}
+
+export default title

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -2,6 +2,8 @@ import { createStore, combineReducers, applyMiddleware } from 'redux'
 import createHistory from 'history/createBrowserHistory'
 import { routerReducer, routerMiddleware } from 'react-router-redux'
 
+import title from './Title/reducers'
+
 import ToDo from './ToDo/reducers'
 import Header from './Header/reducers'
 
@@ -17,7 +19,8 @@ const reducers = {
 export const store = createStore(
   combineReducers({
     ...reducers,
-    router: routerReducer
+    title,
+    router: routerReducer,
   }),
   applyMiddleware(middleware)
 )


### PR DESCRIPTION
<!-- 必ずしも全ての項目を埋めなくてよい -->

# 概要
タイトルの状態を管理して，コンポーネント側から更新できるようにする．
コンポーネントを遷移した際にタイトルをセットし直さないと，以前のタイトルがそのまま使われてしまう点に注意が必要になる．

# 変更内容
`modules` に `Title` を追加した．

# 影響範囲

# 動作要件
<!--
動作に必要な環境変数や依存関係，データベースの更新など
-->

# 補足
<!--
レビューをする際に注意するべき点，ローカル環境で試す際の注意点など
-->
